### PR TITLE
Feature: VPN routing

### DIFF
--- a/qemu-aarch64/02-configure-guest-network.yaml
+++ b/qemu-aarch64/02-configure-guest-network.yaml
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  ethernets:
+    enp0s3:
+      addresses: [192.168.255.2/24]
+      dhcp4: true

--- a/qemu-aarch64/03-configure-guest-slirp-network.yaml
+++ b/qemu-aarch64/03-configure-guest-slirp-network.yaml
@@ -1,0 +1,10 @@
+network:
+  version: 2
+  ethernets:
+    enp0s4:
+      dhcp4: false
+      addresses: [192.168.254.12/24]
+      routes:
+      - to: 172.16.0.0/16
+        via: 192.168.254.2
+       

--- a/qemu-aarch64/README.md
+++ b/qemu-aarch64/README.md
@@ -51,10 +51,13 @@ sudo ifconfig bridge1 addm tap0 addm en0 # add en0 and tap0 as member to bridge1
 sudo ifconfig bridge1 up
 ```
 
-### 5. Overwrite the vm address using Serial 📝 _TODO: move this section to from-iso.sh_
+### 5. Overwrite the vm networking using Serial 📝 _TODO: move this section to from-iso.sh_
 ```sh
 sudo ip addr add 192.168.255.2/24 dev enp0s3
 grep host_machine /etc/hosts || echo  "192.168.255.1 host_machine" >> /etc/hosts
+
+ip r del default via 192.168.254.2 dev enp0s4 proto dhcp metric 101
+ip r add 172.16/16 via 192.168.254.2 dev enp0s4 proto dhcp metric 101 # VPN route, add more such if needed
 ```
 
 ### Mounting host shared directory

--- a/qemu-aarch64/README.md
+++ b/qemu-aarch64/README.md
@@ -42,26 +42,31 @@ cd ~/Documents/virtual-machines/ubuntuaarch64
 sudo /PATH/TO/THIS/REPO/qemu-aarch64/from-iso.sh
 ```
 
+### 4. Copy networking files to /etc/netplan/ using `serial` mode
+- [02-configure-guest-network.yaml](02-configure-guest-network.yaml)
+- [03-configure-guest-slirp-network.yaml](03-configure-guest-slirp-network.yaml)
 
-### 4. Setup the Bridge Interface. 📝 _TODO: move this section to from-iso.sh_
-```sh
-sudo ifconfig en0 inet 192.168.255.1/24 alias
-sudo ifconfig bridge create # create a bridge interface
-sudo ifconfig bridge1 addm tap0 addm en0 # add en0 and tap0 as member to bridge1
-sudo ifconfig bridge1 up
-```
 
-### 5. Overwrite the vm networking using Serial 📝 _TODO: move this section to from-iso.sh_
+### 5. Auto Mounting host shared directory
 ```sh
-sudo ip addr add 192.168.255.2/24 dev enp0s3
 grep host_machine /etc/hosts || echo  "192.168.255.1 host_machine" >> /etc/hosts
-
-ip r del default via 192.168.254.2 dev enp0s4 proto dhcp metric 101
-ip r add 172.16/16 via 192.168.254.2 dev enp0s4 proto dhcp metric 101 # VPN route, add more such if needed
 ```
 
-### Mounting host shared directory
-[Follow the instructions from smbd](../smbd/README.md#mount-on-linux-guest)
+Then follow the [instructions from smbd](../smbd/README.md#mount-on-linux-guest) section
+
+## Troubleshooting 
+### 1. Guest Networking
+
+#### 1.1 Refresh networking from within guest
+```sh
+sudo netplan apply
+```
+
+#### 1.2 Add more VPN routes
+This routes will have affect until restart
+```sh
+ip r add 10.10/16 via 192.168.254.2 dev enp0s4 metric 90
+```
 
 
 ## Status
@@ -69,9 +74,9 @@ ip r add 172.16/16 via 192.168.254.2 dev enp0s4 proto dhcp metric 101 # VPN rout
 - [x] shutdown and starts
 - [x] ssh from host (using tap device)
 - [x] host dir share
-- [ ] access vpn routing 
-- [ ] automount dir share
-- [ ] get vm ip automatically and use while mounting nfs drive, ssh_config
+- [x] access vpn routing 
+- [x] automount dir share
+- [x] get vm ip automatically and use while mounting nfs drive, ssh_config
 - [ ] move back redirecting monitor to stdio, instead of serial
 - [ ] deny installation of kernel extensions by user using Mac OS _Recovery Mode_
 - [ ] Vendor the TunnelBlick repo in this repo

--- a/qemu-aarch64/from-iso.sh
+++ b/qemu-aarch64/from-iso.sh
@@ -26,6 +26,6 @@ qemu-system-aarch64 \
   -device hda-duplex \
   -drive file=ubuntu_ovmf_vars.fd,if=pflash,index=1,format=raw \
   -drive file=ubuntu.qcow2,if=virtio,cache=writethrough \
-  -netdev tap,id=mytap0,ifname=tap0,script=no,downscript=no -device e1000,netdev=mytap0,mac=52:55:00:d1:55:01 \
+  -netdev tap,id=mytap0,ifname=tap0,script=/Users/krishnagupta/Documents/git-repos/dotfiles/qemu-aarch64/qemu-ifup.sh,downscript=/Users/krishnagupta/Documents/git-repos/dotfiles/qemu-aarch64/qemu-ifdown.sh -device e1000,netdev=mytap0,mac=52:55:00:d1:55:01 \
   -netdev user,id=myslirp0,net=192.168.254.0/24,dhcpstart=192.168.254.9 -device e1000,netdev=myslirp0 \
 #  -cdrom ../focal-desktop-arm64.iso #Only during OS install

--- a/qemu-aarch64/from-iso.sh
+++ b/qemu-aarch64/from-iso.sh
@@ -27,4 +27,5 @@ qemu-system-aarch64 \
   -drive file=ubuntu_ovmf_vars.fd,if=pflash,index=1,format=raw \
   -drive file=ubuntu.qcow2,if=virtio,cache=writethrough \
   -netdev tap,id=mytap0,ifname=tap0,script=no,downscript=no -device e1000,netdev=mytap0,mac=52:55:00:d1:55:01 \
+  -netdev user,id=myslirp0,net=192.168.254.0/24,dhcpstart=192.168.254.9 -device e1000,netdev=myslirp0 \
 #  -cdrom ../focal-desktop-arm64.iso #Only during OS install

--- a/qemu-aarch64/qemu-ifdown.sh
+++ b/qemu-aarch64/qemu-ifdown.sh
@@ -1,0 +1,17 @@
+#!/bin/sh 
+# 
+# script to bring up the tun device in QEMU in bridged mode 
+# first parameter is name of tap device (e.g. tap0)
+#
+# some constants specific to the local host - change to suit your host
+#
+
+# Set it to a number which is not already created
+HOST_BRIDGE_IF="bridge1"
+
+if [ -z $HOST_BRIDGE_IF  ]; then 
+    echo "HOST_BRIDGE_IF not set"
+    exit 1
+fi
+
+ifconfig ${HOST_BRIDGE_IF} destroy

--- a/qemu-aarch64/qemu-ifup.sh
+++ b/qemu-aarch64/qemu-ifup.sh
@@ -1,0 +1,44 @@
+#!/bin/sh 
+# 
+# script to bring up the tun device in QEMU in bridged mode 
+# first parameter is name of tap device (e.g. tap0)
+#
+# some constants specific to the local host - change to suit your host
+#
+
+# set it to your wifi network interface
+HOST_ETH_IF="en0"
+
+# Set it to a number which is not already created
+HOST_BRIDGE_IF="bridge1"
+
+HOST_MACHINE_ADDR="192.168.255.1/24"
+
+if [ -z $HOST_ETH_IF  ]; then 
+    echo "HOST_ETH_IF not set"
+    exit 1
+fi
+
+if [ -z $HOST_BRIDGE_IF  ]; then 
+    echo "HOST_BRIDGE_IF not set"
+    exit 1
+fi
+
+if [ -z $HOST_MACHINE_ADDR  ]; then 
+    echo "HOST_MACHINE_ADDR not set"
+    exit 1
+fi
+
+ifconfig ${HOST_BRIDGE_IF} down
+
+# Add an alias ip to host's interface. This will be the main 
+# communication IP
+ifconfig ${HOST_ETH_IF}} inet ${HOST_MACHINE_ADDR} alias
+
+# create the bridge interface
+ifconfig ${HOST_BRIDGE_IF} create 
+
+# add members to the bridge
+ifconfig ${HOST_BRIDGE_IF} addm ${HOST_ETH_IF} addm $1
+
+ifconfig ${HOST_BRIDGE_IF} up


### PR DESCRIPTION
- Route all traffic to net dev tap ✅ 
- Route specific traffic to net dev user aka slirp ✅ 
- Automated host and guest networking ✅ 

Tests
- Test internet speed
Result 👇 
```
kg@kg:/tmp$ curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -
Retrieving speedtest.net configuration...
Testing from Airtel (223.190.xxx.xxx)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by Tripleplay Broadband Pvt Ltd (xxxx) [1.04 km]: 9.536 ms
Testing download speed................................................................................
Download: 119.24 Mbit/s
Testing upload speed......................................................................................................
Upload: 111.75 Mbit/s
```